### PR TITLE
move R code to `/actions.R`; get all data & update web page

### DIFF
--- a/.github/workflows/getdata.yml
+++ b/.github/workflows/getdata.yml
@@ -37,7 +37,8 @@ jobs:
       - name: Get Data
         run: |
           cd main
-          Rscript -e 'library("CoV19"); getdatastates(); getdataitaly(); getdataworld()'
+          # Rscript -e 'library("CoV19"); getdatastates(); getdataitaly(); getdataworld()'
+          Rscript 'actions.R'
       - name: Commit Changes
         run: |
           cd main

--- a/actions.R
+++ b/actions.R
@@ -1,0 +1,6 @@
+## install.packages('devtools')
+## library('devtools')
+## install_github('eeholmes/CoV19')
+library('CoV19')
+getdata()
+updatewebpage()


### PR DESCRIPTION
Hard to test here, might be worth committing and seeing if it works
later tonight.

currently, `updatewebpage()` is erroring out on my machien so there may
be a bug, or a missing dependency. If build fails we will both get
messages.

Consider adding "on push" temporarily to ensure that the build really
happens. With macos build is down to 3 minutes -- R packages seem to
install way faster than on ubuntu.

If this does work, then you can always just add whatever R you want to
`actions.R` in top level of repo, and those commands will be performed
wheneve rthe data is updated.


----

#